### PR TITLE
use full query string as LPI

### DIFF
--- a/src/main/java/de/unigoettingen/sub/commons/resolver/Resolver.java
+++ b/src/main/java/de/unigoettingen/sub/commons/resolver/Resolver.java
@@ -61,25 +61,15 @@ public class Resolver extends HttpServlet {
 
         LinkedList<LocalResolverConnectorThread> allThreads = new LinkedList<LocalResolverConnectorThread>();
 
-        //	 get parameters
-        logger.info("SUBResolver: received a request");
-
-        ArrayList<String> params = Collections.list(request.getParameterNames());
-
-        for (String p : params) {
-            logger.debug("SUBResolver: parameter=" + p);
-        }
-
-        if (params.isEmpty()) {
+        //	 get query string
+        String parameter = request.getQueryString();
+        if (parameter == null) {
             // error handling; no parameter/identifier given
             logger.warn("SUBResolver: didn't receive a parameter");
             return;
-        } else if (params.size() > 1) {
-            // invalid request
-            logger.warn("SUBResolver: wrong number of parameters");
-            return;
         }
-        String parameter = params.get(0);
+
+        logger.info("SUBResolver: received a request for " + parameter);
 
         // just ask all LocalResolver 
         // every connection in done in a seperate thread


### PR DESCRIPTION
before, a call to HttpServletRequest->getParameterNames() was made to gather the LPI, the first entry of the resulting Enumeration was taken to be the LPI. This however would split a query string like ?a=b into isolated parameters, while the LPI definition mandates that the full query string ought to be the LPI. Thus, switch to use the full query string.